### PR TITLE
Modification of the low power cutoff

### DIFF
--- a/src/preprocessing.c
+++ b/src/preprocessing.c
@@ -733,8 +733,8 @@ void Filter_Bad_ACFs(FITPRMS *fit_prms, llist ranges, double noise_pwr){
 	}
 
 
-	cutoff_pwr = ACF_SNR_CUTOFF * noise_pwr * (1 + 1/sqrt(fit_prms->nave));
-
+	cutoff_pwr = noise_pwr * (1. + 3./sqrt(fit_prms->nave));
+	/*Removing low-power ACFs from the analysis by using an upper three-sigma level of the model noise distribution*/
 	llist_reset_iter(ranges);
 
 


### PR DESCRIPTION
Removing low-power ACFs from analysis by using an upper three-sigma level of the model noise distribution. The statistical variance (sigma) depends on the number of averages as 1/sqrt(prm.nave) so using this parameter makes more sense than utilising an arbitrary cut-off level. This also makes ACF_SNR_CUTOFF parameter redundant, so I just removed it from this code. This constant should also be removed from preprocessing.h file in order to avoid further confusion.