### PR TITLE
Setting elevation as measured from lag0 phase only

### DIFF
--- a/src/determinations.c
+++ b/src/determinations.c
@@ -422,7 +422,7 @@ void find_elevation(llist_node range, struct FitElv* fit_elev_array, FITPRMS* fi
 		elevation = asin(sqrt(theta));
 	}
 
-	fit_elev_array[range_node->range].normal = 180/M_PI * (elevation + elev_corr);
+	fit_elev_array[range_node->range].high = 180/M_PI * (elevation + elev_corr);
 
 	/*Elevation errors*/
 	psi_k2d2 = psi/(wave_num * wave_num * antenna_sep * antenna_sep);
@@ -449,7 +449,7 @@ void find_elevation(llist_node range, struct FitElv* fit_elev_array, FITPRMS* fi
 	else{
 		elevation = asin(sqrt(theta));
 	}
-	fit_elev_array[range_node->range].high = 180/M_PI * (elevation + elev_corr);
+	fit_elev_array[range_node->range].normal = 180/M_PI * (elevation + elev_corr);
 
 }
 


### PR DESCRIPTION
Under the original convention, field .normal (fit.elv in the output structure) was assigned to elevation obtained by fitting (as it is set right now) while the fields .low (fit.elv_low) and .high (fit.elv_high) were filled with lower and upper elevation boundaries estimated from adding and subtracting the phase error to and from the fitted lag 0 phase estimate.

In FITACF3 we modified the convention so that .low now contains a standard error obtained through propagation of errors from the phase fitting error and .high contains an estimate from just laf 0 cross phase.

The lag0 way proved to be as good as the conventional fitting for high SNR but provides noticeably lower fluctuations for the data with low SNR, so it makes sense to switch them around. In order to do that, just swap the fields in the code.

For consistency, it is also be necessary to replace the fitted lag 0 phase phi0 by the directly measured one in set_xcf_phi0.